### PR TITLE
Dropped support Python <=3.7. Added tox testing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include README.md
+include LICENSE
+include requirements.txt
+include setup.py
+include tox.ini

--- a/bot.py
+++ b/bot.py
@@ -24,7 +24,7 @@ import asyncio
 #cfg = utils.CoreConfig.modules["modules/core"]["discord"]
 cfg = utils.CoreConfig.cfgDiscord
 
-intents = discord.Intents.default()
+intents = discord.Intents.all()
 intents.members = True  # Subscribe to the privileged members 
 
 bot = commands.Bot(command_prefix=cfg["BOT_PREFIX"], pm_help=True, intents=intents)
@@ -36,6 +36,7 @@ bot.CoreConfig = utils.CoreConfig(bot)
 
 @bot.event
 async def on_ready():
+    utils.Modules.loadCogs(bot)
     log.info('Logged in as {} [{}]'.format(bot.user.name, bot.user.id))
     log.info(bot.guilds)
     log.info('------------')
@@ -43,11 +44,16 @@ async def on_ready():
     for guild in list(bot.guilds):
         roles += await guild.fetch_roles()
     bot.CoreConfig.load_role_permissions(roles)
+    print("Exiting...")
+    for task in asyncio.tasks.all_tasks():
+        task.cancel()
+    print("Exiting... A")    
+    await bot.close()
+    print("Exiting... B")    
+    bot.loop.close()
+    print("Exiting... C")    
 
 def main():
-    
-    utils.Modules.loadCogs(bot)
-    
     try:
         bot.run(cfg["TOKEN"])
     except (KeyboardInterrupt, asyncio.CancelledError):
@@ -60,12 +66,12 @@ def main():
 
 if __name__ == '__main__':
     try:
-        asyncio.run(main())
+        main()
     except (KeyboardInterrupt, asyncio.CancelledError):
         log.info("[DiscordBot] Interrupted")
         
-    if(hasattr(bot, "restarting") and bot.restarting == True):
-        log.info("Restarting")
+    # if(hasattr(bot, "restarting") and bot.restarting == True):
+    #     log.info("Restarting")
         
-        time.sleep(1)
-        subprocess.Popen("python" + " bot.py", shell=True) #TODO: Will not work on all system
+    #     time.sleep(1)
+    #     subprocess.Popen("python" + " bot.py", shell=True) #TODO: Will not work on all system

--- a/modules/arma/module.py
+++ b/modules/arma/module.py
@@ -342,5 +342,5 @@ class CommandArma(commands.Cog):
         self.script_errors = {}
         await ctx.send("Done!")  
 
-def setup(bot):
-    bot.add_cog(CommandArma(bot))
+async def setup(bot):
+    await bot.add_cog(CommandArma(bot))

--- a/modules/core/module.py
+++ b/modules/core/module.py
@@ -3,9 +3,7 @@ from discord.ext.commands import has_permissions, CheckFailure
 import discord
 import os
 
-
-
-import psutil
+import psutil, asyncio
 import datetime
 from modules.core import CoreConfig, CommandChecker
 import modules.core.utils as utils
@@ -63,5 +61,5 @@ class Commandconfig(commands.Cog):
         msg += "```"
         await ctx.send(msg)    
         
-def setup(bot):
-    bot.add_cog(Commandconfig(bot))
+async def setup(bot):
+    await bot.add_cog(Commandconfig(bot))

--- a/modules/errorhandle/module.py
+++ b/modules/errorhandle/module.py
@@ -74,5 +74,5 @@ class CommandErrorHandler(commands.Cog):
         traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
                 
 
-def setup(bot):
-    bot.add_cog(CommandErrorHandler(bot))
+async def setup(bot):
+    await bot.add_cog(CommandErrorHandler(bot))

--- a/modules/rcon/module.py
+++ b/modules/rcon/module.py
@@ -827,6 +827,6 @@ class CommandRcon(commands.Cog):
 
 
 
-def setup(bot):
-    bot.add_cog(CommandRcon(bot))
-    bot.add_cog(CommandRconSettings(bot))
+async def setup(bot):
+    await bot.add_cog(CommandRcon(bot))
+    await bot.add_cog(CommandRconSettings(bot))

--- a/modules/rcon_ban_msg/module.py
+++ b/modules/rcon_ban_msg/module.py
@@ -132,5 +132,5 @@ class CommandRcon_Custom(commands.Cog):
         name, guid = self.name_from_guid(data[1])
         await self.post_channel.send("``{}`` has been **unbanned**!: \nGUID: {}\nTime: {}\nReason: {}".format(name, data[1], data[2], data[3])) 
 
-def setup(bot):
-    bot.add_cog(CommandRcon_Custom(bot))
+async def setup(bot):
+    await bot.add_cog(CommandRcon_Custom(bot))

--- a/modules/rcon_chat_link/module.py
+++ b/modules/rcon_chat_link/module.py
@@ -125,7 +125,7 @@ class CommandChatLink(commands.Cog):
     async def rcon_on_connect(self):
         await self.linkedChannel.send(":white_check_mark: ``Connected ChatLink``")
 
-def setup(bot):
+async def setup(bot):
     module = CommandChatLink(bot)
-    bot.add_cog(module)
+    await bot.add_cog(module)
     

--- a/modules/rcon_database/module.py
+++ b/modules/rcon_database/module.py
@@ -29,7 +29,7 @@ class CommandRconDatabase(commands.Cog):
 
         
         self.upgrade_database()
-        self.alter_database()
+        #self.alter_database() only needed to upgrade from old db
         #self.player_db = CoreConfig.cfg.new(self.path+"/player_db.json")
 
         self.cfg = CoreConfig.modules["modules/rcon_database"]["general"]
@@ -110,6 +110,7 @@ class CommandRconDatabase(commands.Cog):
             log.print_exc()
             log.error(e)
     
+
     def alter_database(self):
         try:
             ## Alter table (upgrade by adding the profileid column)
@@ -124,6 +125,7 @@ class CommandRconDatabase(commands.Cog):
         except Exception as e:
             log.print_exc()
             log.error(e)  
+            log.info("If you are not upgrading an old database, you can ignore the error above.")  
             
     async def fetch_player_data_loop(self):
         while True: 
@@ -460,5 +462,5 @@ class CommandRconDatabase(commands.Cog):
                 msg += "{} ``{}``\n".format(key, val)
         await ctx.send(msg)
         
-def setup(bot):
-    bot.add_cog(CommandRconDatabase(bot))
+async def setup(bot):
+    await bot.add_cog(CommandRconDatabase(bot))

--- a/modules/rcon_ingamge_cmd/module.py
+++ b/modules/rcon_ingamge_cmd/module.py
@@ -377,6 +377,6 @@ class CommandRconTaskScheduler(commands.Cog):
         self.CommandRcon = self.bot.cogs["CommandRcon"]
 
         
-def setup(bot):
-    #bot.add_cog(CommandRconTaskScheduler(bot))
-    bot.add_cog(CommandRconIngameComs(bot))
+async def setup(bot):
+    #await bot.add_cog(CommandRconTaskScheduler(bot))
+    await bot.add_cog(CommandRconIngameComs(bot))

--- a/modules/rcon_jmw/module.py
+++ b/modules/rcon_jmw/module.py
@@ -549,9 +549,9 @@ class CommandJMW(commands.Cog):
         await ctx.send("Saved System data to '{}' ({} entries)".format(filename, len(self.processLog.system_res))) 
                   
     
-def setup(bot):
+async def setup(bot):
     module = CommandJMW(bot)
     bot.loop.create_task(module.task_setStatus())
     bot.loop.create_task(module.task_updatePlayerStats())
-    bot.add_cog(module)
+    await bot.add_cog(module)
     

--- a/modules/rcon_msgs/module.py
+++ b/modules/rcon_msgs/module.py
@@ -68,6 +68,6 @@ class CommandJoinMSG(commands.Cog):
 #####                                  common functions                                        ####
 ###################################################################################################
  
-def setup(bot):
-    bot.add_cog(CommandJoinMSG(bot))
+async def setup(bot):
+    await bot.add_cog(CommandJoinMSG(bot))
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-git+https://github.com/Yoshi-E/Python-BEC-RCon@master#bec_rcon>=0.1.7
-discord>=1.7.3
-discord.py>=1.7.3
+bec_rcon @ git+https://github.com/Yoshi-E/Python-BEC-RCon@master#bec_rcon>=0.1.7
+discord>=2.0.0
+discord.py>=2.0.0
 geoip2>=4.6.0
 packaging>=19.0
 prettytable>=0.7.2
@@ -9,3 +9,7 @@ psutil>=5.9.1
 scipy
 numpy
 func-timeout
+pytest
+pytest-timeout
+Pillow
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+from setuptools import find_packages, setup
+
+with open('requirements.txt') as f:
+    required = f.read().splitlines()
+
+setup(
+    name='ArmaRconDiscordBot',
+    version='0.0.1',
+    packages=find_packages(exclude=['tests']),  # Include all the python modules except `tests`.
+    description='ArmaRconDiscordBot to manage Arma 3 servers with discord',
+    long_description='An open source tool to manage servers with Rcon via Discord',
+    install_requires=required,
+    classifiers=[
+        'Programming Language :: Python',
+    ],
+    entry_points={
+        'pytest11': []
+    },
+)

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,0 +1,10 @@
+import os
+import tempfile
+import pytest
+
+
+# @pytest.fixture(scope='module')
+# def client():
+#     with app.app_context():
+#         with app.test_client() as client:
+#             yield client

--- a/tests/functional/test_Modules.py
+++ b/tests/functional/test_Modules.py
@@ -1,0 +1,38 @@
+import pytest
+import discord
+from discord.ext import commands
+from modules.core import utils
+from modules.core.Log import log
+import asyncio
+import func_timeout
+
+cfg = utils.CoreConfig.cfgDiscord
+
+intents = discord.Intents.default()
+intents.members = True  # Subscribe to the privileged members 
+
+bot = commands.Bot(command_prefix=cfg["BOT_PREFIX"], pm_help=True, intents=intents)
+bot.CoreConfig = utils.CoreConfig(bot)  
+
+@bot.event
+async def on_ready():
+    utils.Modules.loadCogs(bot)
+    log.info('Logged in as {} [{}]'.format(bot.user.name, bot.user.id))
+    log.info(bot.guilds)
+    log.info('------------')
+    roles = []
+    for guild in list(bot.guilds):
+        roles += await guild.fetch_roles()
+    bot.CoreConfig.load_role_permissions(roles)
+    bot.close()
+
+
+@pytest.mark.timeout(30)
+def test_Optimizer():
+    # Load the bot to test it working, then force it to close
+    try:
+        func_timeout.func_timeout(10, bot.run, args=(cfg["TOKEN"],))
+    except func_timeout.FunctionTimedOut:
+        pass
+    assert True
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+[tox]
+envlist = py39, py310
+[testenv]
+commands =
+  pytest {posargs: tests}
+#  isort --check-only --diff --recursive --skip .tox --skip migrations
+#  flake8
+deps =
+  -rrequirements.txt


### PR DESCRIPTION
Discord 2.0.0 changed a lot in terms of function calls.
So support is dropped for Discord.py < 2.0.0 and all python versions that can not run it (3.7 and lower)

Added config and testest to test quickly across python versions.